### PR TITLE
Revamp schedule uploader interface

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,106 @@
 "use client";
 
+import { ShiftPreviewList } from "@/components/ShiftPreviewList";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { cleanKnownLocations } from "@/utils/cleanKnownLocations";
 import { cleanOCRText } from "@/utils/cleantext";
 import { extractTextFromImage } from "@/utils/ocr";
-import { parseScheduleFromOCR } from "@/utils/parser";
-import { useState } from "react";
-import { ScheduleEntry } from "@/utils/parser";
-import { ShiftPreviewList } from "@/components/ShiftPreviewList";
-import { cleanKnownLocations } from "@/utils/cleanKnownLocations";
+import { parseScheduleFromOCR, ScheduleEntry } from "@/utils/parser";
 import { resolveRelativeDates } from "@/utils/resolveRelativeDates";
+import {
+  CalendarRange,
+  Download,
+  ImageIcon,
+  Loader2,
+  Sparkles,
+  UploadCloud,
+  Wand2,
+  X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type Step = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+const steps: Step[] = [
+  {
+    icon: UploadCloud,
+    title: "Upload your schedule",
+    description: "Add a screenshot or photo of the shifts you received from Disney.",
+  },
+  {
+    icon: Wand2,
+    title: "We read and tidy",
+    description: "Our OCR cleans messy text, detects dates, and lines up every shift.",
+  },
+  {
+    icon: CalendarRange,
+    title: "Export in one tap",
+    description: "Download a calendar-ready .ics file for Google, Apple, or Outlook.",
+  },
+];
+
+function formatFileSize(bytes: number) {
+  if (!Number.isFinite(bytes)) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  const index = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** index;
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
 
 export default function Home() {
   const [image, setImage] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [ocrText, setOcrText] = useState("");
   const [loading, setLoading] = useState(false);
   const [parsedSchedule, setParsedSchedule] = useState<ScheduleEntry[]>([]);
 
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setImage(e.target.files[0]);
+  useEffect(() => {
+    if (!image) {
+      setPreviewUrl(null);
+      return undefined;
+    }
+
+    const objectUrl = URL.createObjectURL(image);
+    setPreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [image]);
+
+  const hasSchedule = parsedSchedule.length > 0;
+  const showDebugText = useMemo(
+    () => Boolean(ocrText && process.env.NEXT_PUBLIC_VERCEL_ENV === "preview"),
+    [ocrText]
+  );
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      setImage(event.target.files[0]);
+      setParsedSchedule([]);
       setOcrText("");
     }
+  };
+
+  const handleClearUpload = () => {
+    setImage(null);
+    setParsedSchedule([]);
+    setOcrText("");
   };
 
   const handleRunOCR = async () => {
@@ -41,73 +122,225 @@ export default function Home() {
   const handleDownloadICS = async () => {
     const res = await fetch("/api/generate-ics", {
       method: "POST",
-      headers: { "Content-Type": "applicaiton/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(parsedSchedule),
     });
 
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "disney_schedule.ics";
-    a.click();
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "disney_schedule.ics";
+    link.click();
     URL.revokeObjectURL(url);
   };
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen px-4 py-8 bg-slate-400">
-      <h1 className="text-3xl font-bold mb-6 text-center">
-        Disney Schedule to Calendar
-      </h1>
+    <main className="relative min-h-screen overflow-hidden bg-slate-950">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(167,139,250,0.18),_transparent_55%)]" />
 
-      <label
-        htmlFor="file-upload"
-        className="flex items-center justify-center w-full max-w-sm px-4 py-2 bg-blue-600 text-white rounded-lg shadow-md cursor-pointer hover:bg-blue-700 transition mb-4"
-      >
-        <input
-          id="file-upload"
-          type="file"
-          className="hidden"
-          onChange={handleFileUpload}
-          accept="image/*"
-        />
-        Upload Schedule Image
-      </label>
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-16 sm:px-8">
+        <header className="mx-auto max-w-3xl text-center text-slate-100">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-sm font-medium uppercase tracking-wide text-sky-100 backdrop-blur">
+            <Sparkles className="size-4" />
+            Disney cast member helper
+          </span>
+          <h1 className="mt-6 text-4xl font-semibold sm:text-5xl">
+            Turn your Disney shifts into a polished calendar in seconds
+          </h1>
+          <p className="mt-4 text-lg text-slate-200">
+            Upload your schedule screenshot, let our OCR do the busy work, and download a clean .ics file ready to drop into your favorite calendar.
+          </p>
+        </header>
 
-      {image && (
-        <>
-          <img
-            src={URL.createObjectURL(image)}
-            alt="Uploaded Preview"
-            className="max-h-64 border rounded mb-4"
-          />
-          <button
-            onClick={handleRunOCR}
-            disabled={loading}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition mb-4"
-          >
-            {loading ? "Processing..." : "Extract Text"}
-          </button>
-        </>
-      )}
-      {ocrText && process.env.NEXT_PUBLIC_VERCEL_ENV === "preview" && (
-        <div className="mt-6 w-full max-w-2xl bg-gray-100 p-4 rounded text-sm whitespace-pre-wrap">
-          <h2 className="font-semibold text-lg mb-2">OCR Result:</h2>
-          <p className="text-black">{ocrText}</p>
+        <div className="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <Card className="border-white/20 bg-white/80 shadow-xl backdrop-blur">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">
+                <Wand2 className="size-6 text-sky-500" />
+                Create your calendar export
+              </CardTitle>
+              <CardDescription className="text-slate-600">
+                Pick a schedule image below. We will parse it, highlight the shifts we find, and prep an .ics file for download.
+              </CardDescription>
+              {image && (
+                <CardAction>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-slate-500 hover:text-slate-900"
+                    onClick={handleClearUpload}
+                  >
+                    <X className="size-4" />
+                    Clear
+                  </Button>
+                </CardAction>
+              )}
+            </CardHeader>
+            <CardContent className="space-y-8">
+              <label
+                htmlFor="file-upload"
+                className={cn(
+                  "group relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center transition hover:border-sky-400 hover:bg-white",
+                  image && "border-sky-400 bg-white"
+                )}
+              >
+                <input
+                  id="file-upload"
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  onChange={handleFileUpload}
+                />
+                <div className="flex size-16 items-center justify-center rounded-full bg-sky-100 text-sky-500 transition group-hover:scale-105">
+                  <UploadCloud className="size-7" />
+                </div>
+                {image ? (
+                  <>
+                    <p className="text-base font-semibold text-slate-900">
+                      {image.name}
+                    </p>
+                    <p className="text-sm text-slate-500">{formatFileSize(image.size)}</p>
+                    <p className="text-xs text-slate-400">
+                      Need a different image? Click to replace it.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-lg font-semibold text-slate-900">
+                      Drag & drop or browse for your schedule
+                    </p>
+                    <p className="text-sm text-slate-500">
+                      JPG, PNG, and HEIC images are supported. Larger photos may take a few seconds to process.
+                    </p>
+                  </>
+                )}
+              </label>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                {steps.map(({ icon: Icon, title, description }, index) => (
+                  <div
+                    key={title}
+                    className="rounded-xl border border-slate-200/70 bg-white/70 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+                  >
+                    <div className="flex size-10 items-center justify-center rounded-full bg-sky-100 text-sky-500">
+                      <Icon className="size-5" aria-hidden />
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-slate-900">
+                      {index + 1}. {title}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-600">{description}</p>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Button
+                type="button"
+                onClick={handleRunOCR}
+                disabled={!image || loading}
+                className="w-full gap-2 sm:w-auto"
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Processing image…
+                  </>
+                ) : (
+                  <>
+                    <Wand2 className="size-4" />
+                    Extract shifts
+                  </>
+                )}
+              </Button>
+
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleDownloadICS}
+                disabled={!hasSchedule}
+                className="w-full gap-2 border-slate-300 text-slate-700 hover:border-sky-400 hover:text-sky-600 sm:w-auto"
+              >
+                <Download className="size-4" />
+                Download .ics file
+              </Button>
+            </CardFooter>
+          </Card>
+
+          <div className="flex flex-col gap-6">
+            <Card className="border-white/30 bg-white/70 shadow-lg backdrop-blur">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
+                  <ImageIcon className="size-5 text-sky-500" />
+                  Uploaded preview
+                </CardTitle>
+                <CardDescription className="text-slate-600">
+                  Make sure everything is readable—clear photos lead to better OCR results.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {previewUrl ? (
+                  <div className="overflow-hidden rounded-xl border border-slate-200 shadow-inner">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={previewUrl}
+                      alt="Uploaded schedule preview"
+                      className="max-h-[22rem] w-full object-contain bg-slate-100"
+                    />
+                  </div>
+                ) : (
+                  <div className="flex h-64 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-300 bg-white/70 text-center text-slate-500">
+                    <ImageIcon className="size-8 text-slate-300" />
+                    <p className="text-sm font-medium">No image uploaded yet</p>
+                    <p className="text-xs text-slate-400">Your preview will appear here after you choose a file.</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-white/30 bg-white/80 shadow-lg backdrop-blur">
+              <CardHeader className="flex flex-wrap items-center gap-2">
+                <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
+                  <CalendarRange className="size-5 text-sky-500" />
+                  Shift preview
+                </CardTitle>
+                {hasSchedule && (
+                  <span className="rounded-full bg-sky-100 px-3 py-1 text-sm font-medium text-sky-600">
+                    {parsedSchedule.length} shift{parsedSchedule.length > 1 ? "s" : ""} detected
+                  </span>
+                )}
+                <CardDescription className="basis-full text-slate-600">
+                  We’ll list each shift as soon as the image has been processed.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                {hasSchedule ? (
+                  <ShiftPreviewList shifts={parsedSchedule} />
+                ) : (
+                  <div className="rounded-xl border border-dashed border-slate-300 bg-white/60 p-6 text-center text-slate-500">
+                    <p className="text-sm font-medium">
+                      No shifts yet—run the extractor to see them here.
+                    </p>
+                    <p className="mt-2 text-xs text-slate-400">
+                      Tip: double-check that dates and start/end times are clearly visible in your upload.
+                    </p>
+                  </div>
+                )}
+
+                {showDebugText && (
+                  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 text-left text-xs text-slate-600">
+                    <p className="font-semibold uppercase tracking-wide text-slate-500">OCR output</p>
+                    <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap font-mono text-[11px]">
+                      {ocrText}
+                    </pre>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
         </div>
-      )}
-      {parsedSchedule.length > 0 && (
-        <ShiftPreviewList shifts={parsedSchedule} />
-      )}
-
-      {parsedSchedule?.length > 0 && (
-        <button
-          onClick={handleDownloadICS}
-          className="mt-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green700"
-        >
-          Download .ics File
-        </button>
-      )}
+      </div>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,6 +77,17 @@ export default function Home() {
 
   const hasSchedule = parsedSchedule.length > 0;
 
+  useEffect(() => {
+    if (!isPreviewOpen) return undefined;
+
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [isPreviewOpen]);
+
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
       setImage(event.target.files[0]);
@@ -158,11 +169,17 @@ export default function Home() {
           </p>
           <div className="mt-8 grid w-full gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 text-left text-slate-100 backdrop-blur sm:grid-cols-3">
             {steps.map(({ icon: Icon, title, description }, index) => (
-              <div key={title} className="flex flex-col gap-3 rounded-2xl border border-white/20 bg-white/5 p-4">
-                <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100">
+              <div
+                key={title}
+                className="group relative flex flex-col gap-3 overflow-hidden rounded-2xl border border-white/20 bg-white/5 p-4 shadow-lg shadow-slate-950/20 transition duration-300 hover:-translate-y-1 hover:border-sky-300/60 hover:shadow-sky-500/30"
+              >
+                <span className="pointer-events-none absolute inset-0 opacity-0 transition duration-300 group-hover:opacity-100">
+                  <span className="absolute inset-0 bg-gradient-to-br from-sky-400/15 via-transparent to-violet-400/20" />
+                </span>
+                <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100 transition-transform duration-300 group-hover:scale-105 group-hover:border-sky-200/80 group-hover:bg-white/20">
                   <Icon className="size-5" aria-hidden />
                 </span>
-                <div>
+                <div className="relative">
                   <p className="text-sm font-semibold uppercase tracking-wide text-sky-100/90">
                     Step {index + 1}: {title}
                   </p>
@@ -346,7 +363,7 @@ export default function Home() {
 
       {isPreviewOpen && previewUrl && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-slate-950/90 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
         >
@@ -356,14 +373,20 @@ export default function Home() {
             onClick={handleClosePreview}
             aria-label="Close preview"
           />
-          <div className="relative z-10 mx-auto flex max-h-[90vh] max-w-4xl items-center justify-center p-6">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={previewUrl} alt="Full size schedule preview" className="max-h-full w-full rounded-2xl object-contain shadow-2xl" />
+          <div className="relative z-10 mx-auto w-full max-w-5xl p-6">
+            <div className="relative mx-auto max-h-[calc(100vh-3rem)] overflow-auto rounded-3xl border border-white/20 bg-slate-950/70 p-4 shadow-2xl">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="Full size schedule preview"
+                className="mx-auto block h-auto max-h-[calc(100vh-7rem)] w-full max-w-full object-contain"
+              />
+            </div>
             <Button
               type="button"
               size="icon"
               variant="secondary"
-              className="absolute right-6 top-6 rounded-full bg-white/90 text-slate-900 hover:bg-white"
+              className="absolute right-10 top-10 rounded-full bg-white/90 text-slate-900 hover:bg-white"
               onClick={handleClosePreview}
             >
               <X className="size-5" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,6 +60,8 @@ export default function Home() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const uploaderRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isUploaderHighlighted, setIsUploaderHighlighted] = useState(false);
 
   useEffect(() => {
     if (!image) {
@@ -142,7 +144,24 @@ export default function Home() {
 
   const handleScrollToUploader = () => {
     uploaderRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    setIsUploaderHighlighted(true);
+
+    if (highlightTimeoutRef.current) {
+      clearTimeout(highlightTimeoutRef.current);
+    }
+
+    highlightTimeoutRef.current = setTimeout(() => {
+      setIsUploaderHighlighted(false);
+    }, 1400);
   };
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current) {
+        clearTimeout(highlightTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <main className="relative min-h-screen overflow-hidden bg-slate-950">
@@ -187,8 +206,17 @@ export default function Home() {
           </div>
         </header>
 
-        <div ref={uploaderRef} className="mt-16 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-          <Card className="border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur">
+        <div
+          ref={uploaderRef}
+          className="mt-16 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]"
+        >
+          <Card
+            className={cn(
+              "border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur",
+              isUploaderHighlighted &&
+                "ring-2 ring-sky-400/80 ring-offset-2 ring-offset-slate-950/40 transition duration-500 ease-out"
+            )}
+          >
             <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-2">
                 <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,7 +57,8 @@ export default function Home() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [parsedSchedule, setParsedSchedule] = useState<ScheduleEntry[]>([]);
-  const [zoom, setZoom] = useState(1);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const uploaderRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -80,14 +81,14 @@ export default function Home() {
     if (event.target.files && event.target.files.length > 0) {
       setImage(event.target.files[0]);
       setParsedSchedule([]);
-      setZoom(1);
+      setIsPreviewOpen(false);
     }
   };
 
   const handleClearUpload = () => {
     setImage(null);
     setParsedSchedule([]);
-    setZoom(1);
+    setIsPreviewOpen(false);
   };
 
   const handleReplacePhoto = () => {
@@ -130,6 +131,19 @@ export default function Home() {
     URL.revokeObjectURL(url);
   };
 
+  const handleOpenPreview = () => {
+    if (!previewUrl) return;
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
+
+  const handleScrollToUploader = () => {
+    uploaderRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <main className="relative min-h-screen overflow-hidden bg-slate-950">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(167,139,250,0.18),_transparent_55%)]" />
@@ -146,9 +160,34 @@ export default function Home() {
           <p className="mt-4 text-lg text-slate-200">
             Upload your schedule screenshot, let our OCR do the busy work, and download a clean .ics file ready to drop into your favorite calendar.
           </p>
+          <div className="mt-8 flex flex-col items-center gap-4">
+            <div className="grid w-full gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 text-left text-slate-100 backdrop-blur sm:grid-cols-3">
+              {steps.map(({ icon: Icon, title, description }, index) => (
+                <div key={title} className="flex flex-col gap-3 rounded-2xl border border-white/20 bg-white/5 p-4">
+                  <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100">
+                    <Icon className="size-5" aria-hidden />
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-wide text-sky-100/90">
+                      Step {index + 1}: {title}
+                    </p>
+                    <p className="mt-2 text-sm text-slate-200/80">{description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <Button
+              type="button"
+              size="lg"
+              className="gap-2 bg-sky-500 text-white hover:bg-sky-500/90"
+              onClick={handleScrollToUploader}
+            >
+              Let&apos;s go
+            </Button>
+          </div>
         </header>
 
-        <div className="mt-12 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+        <div ref={uploaderRef} className="mt-16 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
           <Card className="border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur">
             <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-2">
@@ -157,8 +196,7 @@ export default function Home() {
                   Upload & preview your schedule
                 </CardTitle>
                 <CardDescription className="max-w-xl text-slate-600">
-                  Start by selecting a screenshot of your shifts. You can zoom in to double-check details before running the
-                  extractor.
+                  Start by selecting a screenshot of your shifts. Tap the preview to pop it into a distraction-free full-screen view before running the extractor.
                 </CardDescription>
               </div>
               {image && (
@@ -188,15 +226,14 @@ export default function Home() {
                 <div className="space-y-5">
                   <div
                     role="presentation"
-                    className="group relative max-h-[28rem] overflow-auto rounded-3xl border border-slate-200/80 bg-slate-950/60 shadow-inner"
+                    className="group relative max-h-[28rem] overflow-hidden rounded-3xl border border-slate-200/80 bg-slate-950/60 shadow-inner"
                   >
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={previewUrl}
                       alt="Uploaded schedule preview"
-                      style={{ transform: `scale(${zoom})`, transformOrigin: "center top" }}
-                      className="mx-auto block max-h-[32rem] w-full origin-center bg-slate-900/40 object-contain transition-transform duration-300 ease-out"
-                      onClick={handleReplacePhoto}
+                      className="mx-auto block max-h-[32rem] w-full origin-center bg-slate-900/40 object-contain transition duration-300 ease-out group-hover:scale-[1.02]"
+                      onClick={handleOpenPreview}
                     />
 
                     <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-3 bg-gradient-to-t from-slate-950/90 via-slate-950/50 to-transparent p-4 text-slate-100">
@@ -214,23 +251,6 @@ export default function Home() {
                         <UploadCloud className="size-3.5" />
                         Replace photo
                       </Button>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-inner sm:flex-row sm:items-center sm:justify-between">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Zoom</div>
-                    <div className="flex w-full items-center gap-3 sm:w-auto">
-                      <input
-                        type="range"
-                        min={1}
-                        max={2.5}
-                        step={0.1}
-                        value={zoom}
-                        onChange={(event) => setZoom(Number(event.target.value))}
-                        className="h-2 w-full flex-1 cursor-pointer appearance-none rounded-full bg-slate-200 accent-sky-500"
-                        aria-label="Zoom uploaded schedule"
-                      />
-                      <span className="w-16 text-right text-sm font-semibold text-slate-600">{Math.round(zoom * 100)}%</span>
                     </div>
                   </div>
                 </div>
@@ -254,22 +274,6 @@ export default function Home() {
                 </label>
               )}
 
-              <div className="grid gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm sm:grid-cols-3">
-                {steps.map(({ icon: Icon, title, description }, index) => (
-                  <div
-                    key={title}
-                    className="rounded-xl border border-white/60 bg-white/70 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
-                  >
-                    <div className="flex size-10 items-center justify-center rounded-full bg-sky-100 text-sky-500">
-                      <Icon className="size-5" aria-hidden />
-                    </div>
-                    <p className="mt-3 text-sm font-semibold text-slate-900">
-                      {index + 1}. {title}
-                    </p>
-                    <p className="mt-1 text-sm text-slate-600">{description}</p>
-                  </div>
-                ))}
-              </div>
             </CardContent>
             <CardFooter className="flex flex-col gap-4 border-t border-slate-200/70 pt-6 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-slate-500">Run the extractor to populate your shifts, then export them to your calendar.</p>
@@ -347,40 +351,38 @@ export default function Home() {
               </CardContent>
             </Card>
 
-            <Card className="border-white/30 bg-white/75 shadow-lg shadow-sky-500/5 backdrop-blur">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-lg text-slate-900">
-                  <Sparkles className="size-5 text-sky-500" />
-                  How it works
-                </CardTitle>
-                <CardDescription className="text-slate-600">
-                  A quick walkthrough of what happens after you upload.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ol className="space-y-4">
-                  {steps.map(({ icon: Icon, title, description }, index) => (
-                    <li
-                      key={title}
-                      className="flex items-start gap-4 rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
-                    >
-                      <span className="flex size-10 items-center justify-center rounded-full bg-sky-100 text-sky-500">
-                        <Icon className="size-5" aria-hidden />
-                      </span>
-                      <div>
-                        <p className="text-sm font-semibold text-slate-900">
-                          Step {index + 1}: {title}
-                        </p>
-                        <p className="mt-1 text-sm text-slate-600">{description}</p>
-                      </div>
-                    </li>
-                  ))}
-                </ol>
-              </CardContent>
-            </Card>
           </div>
         </div>
       </div>
+
+      {isPreviewOpen && previewUrl && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+        >
+          <button
+            type="button"
+            className="absolute inset-0 z-0 h-full w-full cursor-zoom-out"
+            onClick={handleClosePreview}
+            aria-label="Close preview"
+          />
+          <div className="relative z-10 mx-auto flex max-h-[90vh] max-w-4xl items-center justify-center p-6">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={previewUrl} alt="Full size schedule preview" className="max-h-full w-full rounded-2xl object-contain shadow-2xl" />
+            <Button
+              type="button"
+              size="icon"
+              variant="secondary"
+              className="absolute right-6 top-6 rounded-full bg-white/90 text-slate-900 hover:bg-white"
+              onClick={handleClosePreview}
+            >
+              <X className="size-5" />
+              <span className="sr-only">Close preview</span>
+            </Button>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,8 +60,6 @@ export default function Home() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const uploaderRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [isUploaderHighlighted, setIsUploaderHighlighted] = useState(false);
 
   useEffect(() => {
     if (!image) {
@@ -142,27 +140,6 @@ export default function Home() {
     setIsPreviewOpen(false);
   };
 
-  const handleScrollToUploader = () => {
-    uploaderRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    setIsUploaderHighlighted(true);
-
-    if (highlightTimeoutRef.current) {
-      clearTimeout(highlightTimeoutRef.current);
-    }
-
-    highlightTimeoutRef.current = setTimeout(() => {
-      setIsUploaderHighlighted(false);
-    }, 1400);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current);
-      }
-    };
-  }, []);
-
   return (
     <main className="relative min-h-screen overflow-hidden bg-slate-950">
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(167,139,250,0.18),_transparent_55%)]" />
@@ -179,30 +156,20 @@ export default function Home() {
           <p className="mt-4 text-lg text-slate-200">
             Upload your schedule screenshot, let our OCR do the busy work, and download a clean .ics file ready to drop into your favorite calendar.
           </p>
-          <div className="mt-8 flex flex-col items-center gap-4">
-            <div className="grid w-full gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 text-left text-slate-100 backdrop-blur sm:grid-cols-3">
-              {steps.map(({ icon: Icon, title, description }, index) => (
-                <div key={title} className="flex flex-col gap-3 rounded-2xl border border-white/20 bg-white/5 p-4">
-                  <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100">
-                    <Icon className="size-5" aria-hidden />
-                  </span>
-                  <div>
-                    <p className="text-sm font-semibold uppercase tracking-wide text-sky-100/90">
-                      Step {index + 1}: {title}
-                    </p>
-                    <p className="mt-2 text-sm text-slate-200/80">{description}</p>
-                  </div>
+          <div className="mt-8 grid w-full gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 text-left text-slate-100 backdrop-blur sm:grid-cols-3">
+            {steps.map(({ icon: Icon, title, description }, index) => (
+              <div key={title} className="flex flex-col gap-3 rounded-2xl border border-white/20 bg-white/5 p-4">
+                <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100">
+                  <Icon className="size-5" aria-hidden />
+                </span>
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-wide text-sky-100/90">
+                    Step {index + 1}: {title}
+                  </p>
+                  <p className="mt-2 text-sm text-slate-200/80">{description}</p>
                 </div>
-              ))}
-            </div>
-            <Button
-              type="button"
-              size="lg"
-              className="gap-2 bg-sky-500 text-white hover:bg-sky-500/90"
-              onClick={handleScrollToUploader}
-            >
-              Let&apos;s go
-            </Button>
+              </div>
+            ))}
           </div>
         </header>
 
@@ -210,13 +177,7 @@ export default function Home() {
           ref={uploaderRef}
           className="mt-16 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]"
         >
-          <Card
-            className={cn(
-              "border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur",
-              isUploaderHighlighted &&
-                "ring-2 ring-sky-400/80 ring-offset-2 ring-offset-slate-950/40 transition duration-500 ease-out"
-            )}
-          >
+          <Card className="border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur">
             <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-2">
                 <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { ShiftPreviewList } from "@/components/ShiftPreviewList";
 import { Button } from "@/components/ui/button";
 import {
   Card,
-  CardAction,
   CardContent,
   CardDescription,
   CardFooter,
@@ -17,18 +16,9 @@ import { cleanOCRText } from "@/utils/cleantext";
 import { extractTextFromImage } from "@/utils/ocr";
 import { parseScheduleFromOCR, ScheduleEntry } from "@/utils/parser";
 import { resolveRelativeDates } from "@/utils/resolveRelativeDates";
-import {
-  CalendarRange,
-  Download,
-  ImageIcon,
-  Loader2,
-  Sparkles,
-  UploadCloud,
-  Wand2,
-  X,
-} from "lucide-react";
+import { CalendarRange, Download, Loader2, Sparkles, UploadCloud, Wand2, X } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Step = {
   icon: LucideIcon;
@@ -65,9 +55,10 @@ function formatFileSize(bytes: number) {
 export default function Home() {
   const [image, setImage] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [ocrText, setOcrText] = useState("");
   const [loading, setLoading] = useState(false);
   const [parsedSchedule, setParsedSchedule] = useState<ScheduleEntry[]>([]);
+  const [zoom, setZoom] = useState(1);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!image) {
@@ -84,39 +75,43 @@ export default function Home() {
   }, [image]);
 
   const hasSchedule = parsedSchedule.length > 0;
-  const showDebugText = useMemo(
-    () => Boolean(ocrText && process.env.NEXT_PUBLIC_VERCEL_ENV === "preview"),
-    [ocrText]
-  );
 
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
       setImage(event.target.files[0]);
       setParsedSchedule([]);
-      setOcrText("");
+      setZoom(1);
     }
   };
 
   const handleClearUpload = () => {
     setImage(null);
     setParsedSchedule([]);
-    setOcrText("");
+    setZoom(1);
+  };
+
+  const handleReplacePhoto = () => {
+    fileInputRef.current?.click();
   };
 
   const handleRunOCR = async () => {
     if (!image) return;
     setLoading(true);
+    setParsedSchedule([]);
 
-    const text = await extractTextFromImage(image);
-    const cleanedText = cleanOCRText(text);
-    const withDates = resolveRelativeDates(cleanedText);
-    const finalText = withDates.split("\n").map(cleanKnownLocations).join("\n");
+    try {
+      const text = await extractTextFromImage(image);
+      const cleanedText = cleanOCRText(text);
+      const withDates = resolveRelativeDates(cleanedText);
+      const finalText = withDates.split("\n").map(cleanKnownLocations).join("\n");
 
-    setOcrText(finalText);
-
-    const parsed = parseScheduleFromOCR(finalText);
-    setParsedSchedule(parsed);
-    setLoading(false);
+      const parsed = parseScheduleFromOCR(finalText);
+      setParsedSchedule(parsed);
+    } catch (error) {
+      console.error("Failed to extract schedule", error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleDownloadICS = async () => {
@@ -153,76 +148,117 @@ export default function Home() {
           </p>
         </header>
 
-        <div className="mt-12 grid flex-1 gap-8 lg:grid-cols-[1.1fr_0.9fr]">
-          <Card className="border-white/20 bg-white/80 shadow-xl backdrop-blur">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">
-                <Wand2 className="size-6 text-sky-500" />
-                Create your calendar export
-              </CardTitle>
-              <CardDescription className="text-slate-600">
-                Pick a schedule image below. We will parse it, highlight the shifts we find, and prep an .ics file for download.
-              </CardDescription>
+        <div className="mt-12 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+          <Card className="border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur">
+            <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">
+                  <Wand2 className="size-6 text-sky-500" />
+                  Upload & preview your schedule
+                </CardTitle>
+                <CardDescription className="max-w-xl text-slate-600">
+                  Start by selecting a screenshot of your shifts. You can zoom in to double-check details before running the
+                  extractor.
+                </CardDescription>
+              </div>
               {image && (
-                <CardAction>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="text-slate-500 hover:text-slate-900"
-                    onClick={handleClearUpload}
-                  >
-                    <X className="size-4" />
-                    Clear
-                  </Button>
-                </CardAction>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="self-start text-slate-500 hover:text-slate-900"
+                  onClick={handleClearUpload}
+                >
+                  <X className="size-4" />
+                  Remove image
+                </Button>
               )}
             </CardHeader>
             <CardContent className="space-y-8">
-              <label
-                htmlFor="file-upload"
-                className={cn(
-                  "group relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-slate-300 bg-white/70 px-6 py-10 text-center transition hover:border-sky-400 hover:bg-white",
-                  image && "border-sky-400 bg-white"
-                )}
-              >
-                <input
-                  id="file-upload"
-                  type="file"
-                  accept="image/*"
-                  className="sr-only"
-                  onChange={handleFileUpload}
-                />
-                <div className="flex size-16 items-center justify-center rounded-full bg-sky-100 text-sky-500 transition group-hover:scale-105">
-                  <UploadCloud className="size-7" />
-                </div>
-                {image ? (
-                  <>
-                    <p className="text-base font-semibold text-slate-900">
-                      {image.name}
-                    </p>
-                    <p className="text-sm text-slate-500">{formatFileSize(image.size)}</p>
-                    <p className="text-xs text-slate-400">
-                      Need a different image? Click to replace it.
-                    </p>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-lg font-semibold text-slate-900">
-                      Drag & drop or browse for your schedule
-                    </p>
-                    <p className="text-sm text-slate-500">
-                      JPG, PNG, and HEIC images are supported. Larger photos may take a few seconds to process.
-                    </p>
-                  </>
-                )}
-              </label>
+              <input
+                id="file-upload"
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                onChange={handleFileUpload}
+              />
 
-              <div className="grid gap-4 sm:grid-cols-3">
+              {image && previewUrl ? (
+                <div className="space-y-5">
+                  <div
+                    role="presentation"
+                    className="group relative max-h-[28rem] overflow-auto rounded-3xl border border-slate-200/80 bg-slate-950/60 shadow-inner"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={previewUrl}
+                      alt="Uploaded schedule preview"
+                      style={{ transform: `scale(${zoom})`, transformOrigin: "center top" }}
+                      className="mx-auto block max-h-[32rem] w-full origin-center bg-slate-900/40 object-contain transition-transform duration-300 ease-out"
+                      onClick={handleReplacePhoto}
+                    />
+
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-3 bg-gradient-to-t from-slate-950/90 via-slate-950/50 to-transparent p-4 text-slate-100">
+                      <div>
+                        <p className="text-sm font-semibold leading-tight">{image.name}</p>
+                        <p className="text-xs text-slate-300/80">{formatFileSize(image.size)}</p>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="pointer-events-auto bg-white/90 text-slate-900 hover:bg-white"
+                        onClick={handleReplacePhoto}
+                      >
+                        <UploadCloud className="size-3.5" />
+                        Replace photo
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-inner sm:flex-row sm:items-center sm:justify-between">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Zoom</div>
+                    <div className="flex w-full items-center gap-3 sm:w-auto">
+                      <input
+                        type="range"
+                        min={1}
+                        max={2.5}
+                        step={0.1}
+                        value={zoom}
+                        onChange={(event) => setZoom(Number(event.target.value))}
+                        className="h-2 w-full flex-1 cursor-pointer appearance-none rounded-full bg-slate-200 accent-sky-500"
+                        aria-label="Zoom uploaded schedule"
+                      />
+                      <span className="w-16 text-right text-sm font-semibold text-slate-600">{Math.round(zoom * 100)}%</span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <label
+                  htmlFor="file-upload"
+                  className={cn(
+                    "group relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border-2 border-dashed border-slate-300 bg-white/75 px-8 py-16 text-center transition hover:border-sky-400 hover:bg-white",
+                    loading && "pointer-events-none opacity-70"
+                  )}
+                >
+                  <div className="flex size-20 items-center justify-center rounded-full bg-sky-100 text-sky-500 shadow-inner transition group-hover:scale-105">
+                    <UploadCloud className="size-8" />
+                  </div>
+                  <p className="text-xl font-semibold text-slate-900">Drag & drop or browse for your schedule</p>
+                  <p className="max-w-md text-sm text-slate-500">
+                    JPG, PNG, and HEIC images are supported. Crystal clear photos give the extractor the best chance to nail every
+                    shift.
+                  </p>
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Click to choose a file</span>
+                </label>
+              )}
+
+              <div className="grid gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm sm:grid-cols-3">
                 {steps.map(({ icon: Icon, title, description }, index) => (
                   <div
                     key={title}
-                    className="rounded-xl border border-slate-200/70 bg-white/70 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+                    className="rounded-xl border border-white/60 bg-white/70 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
                   >
                     <div className="flex size-10 items-center justify-center rounded-full bg-sky-100 text-sky-500">
                       <Icon className="size-5" aria-hidden />
@@ -235,71 +271,44 @@ export default function Home() {
                 ))}
               </div>
             </CardContent>
-            <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <Button
-                type="button"
-                onClick={handleRunOCR}
-                disabled={!image || loading}
-                className="w-full gap-2 sm:w-auto"
-              >
-                {loading ? (
-                  <>
-                    <Loader2 className="size-4 animate-spin" />
-                    Processing image…
-                  </>
-                ) : (
-                  <>
-                    <Wand2 className="size-4" />
-                    Extract shifts
-                  </>
-                )}
-              </Button>
+            <CardFooter className="flex flex-col gap-4 border-t border-slate-200/70 pt-6 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-slate-500">Run the extractor to populate your shifts, then export them to your calendar.</p>
+              <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+                <Button
+                  type="button"
+                  onClick={handleRunOCR}
+                  disabled={!image || loading}
+                  className="w-full gap-2 bg-sky-500 text-white hover:bg-sky-500/90 sm:w-auto"
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Scanning upload…
+                    </>
+                  ) : (
+                    <>
+                      <Wand2 className="size-4" />
+                      Extract shifts
+                    </>
+                  )}
+                </Button>
 
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleDownloadICS}
-                disabled={!hasSchedule}
-                className="w-full gap-2 border-slate-300 text-slate-700 hover:border-sky-400 hover:text-sky-600 sm:w-auto"
-              >
-                <Download className="size-4" />
-                Download .ics file
-              </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleDownloadICS}
+                  disabled={!hasSchedule}
+                  className="w-full gap-2 border-slate-300 text-slate-700 hover:border-sky-400 hover:text-sky-600 sm:w-auto"
+                >
+                  <Download className="size-4" />
+                  Download .ics file
+                </Button>
+              </div>
             </CardFooter>
           </Card>
 
           <div className="flex flex-col gap-6">
-            <Card className="border-white/30 bg-white/70 shadow-lg backdrop-blur">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
-                  <ImageIcon className="size-5 text-sky-500" />
-                  Uploaded preview
-                </CardTitle>
-                <CardDescription className="text-slate-600">
-                  Make sure everything is readable—clear photos lead to better OCR results.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {previewUrl ? (
-                  <div className="overflow-hidden rounded-xl border border-slate-200 shadow-inner">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={previewUrl}
-                      alt="Uploaded schedule preview"
-                      className="max-h-[22rem] w-full object-contain bg-slate-100"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-64 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-300 bg-white/70 text-center text-slate-500">
-                    <ImageIcon className="size-8 text-slate-300" />
-                    <p className="text-sm font-medium">No image uploaded yet</p>
-                    <p className="text-xs text-slate-400">Your preview will appear here after you choose a file.</p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            <Card className="border-white/30 bg-white/80 shadow-lg backdrop-blur">
+            <Card className="border-white/30 bg-white/80 shadow-xl shadow-sky-500/5 backdrop-blur">
               <CardHeader className="flex flex-wrap items-center gap-2">
                 <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
                   <CalendarRange className="size-5 text-sky-500" />
@@ -311,31 +320,62 @@ export default function Home() {
                   </span>
                 )}
                 <CardDescription className="basis-full text-slate-600">
-                  We’ll list each shift as soon as the image has been processed.
+                  Review the extracted shifts below. We’ll keep them ordered exactly as they appear on your schedule.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
-                {hasSchedule ? (
-                  <ShiftPreviewList shifts={parsedSchedule} />
-                ) : (
-                  <div className="rounded-xl border border-dashed border-slate-300 bg-white/60 p-6 text-center text-slate-500">
-                    <p className="text-sm font-medium">
-                      No shifts yet—run the extractor to see them here.
-                    </p>
-                    <p className="mt-2 text-xs text-slate-400">
-                      Tip: double-check that dates and start/end times are clearly visible in your upload.
-                    </p>
+                {loading && (
+                  <div className="flex items-center gap-3 rounded-2xl border border-sky-200 bg-sky-50/80 p-4 text-sky-700">
+                    <Loader2 className="size-4 animate-spin" />
+                    <div>
+                      <p className="text-sm font-medium">Scanning your upload</p>
+                      <p className="text-xs text-sky-600/80">Hang tight—this usually wraps up in just a few seconds.</p>
+                    </div>
                   </div>
                 )}
 
-                {showDebugText && (
-                  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 text-left text-xs text-slate-600">
-                    <p className="font-semibold uppercase tracking-wide text-slate-500">OCR output</p>
-                    <pre className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap font-mono text-[11px]">
-                      {ocrText}
-                    </pre>
+                {hasSchedule ? (
+                  <ShiftPreviewList shifts={parsedSchedule} />
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-slate-300 bg-white/60 p-6 text-center text-slate-500">
+                    <p className="text-sm font-medium">No shifts yet—run the extractor to see them here.</p>
+                    <p className="mt-2 text-xs text-slate-400">
+                      Tip: ensure dates and times are sharp and unobstructed for the most accurate results.
+                    </p>
                   </div>
                 )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-white/30 bg-white/75 shadow-lg shadow-sky-500/5 backdrop-blur">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg text-slate-900">
+                  <Sparkles className="size-5 text-sky-500" />
+                  How it works
+                </CardTitle>
+                <CardDescription className="text-slate-600">
+                  A quick walkthrough of what happens after you upload.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ol className="space-y-4">
+                  {steps.map(({ icon: Icon, title, description }, index) => (
+                    <li
+                      key={title}
+                      className="flex items-start gap-4 rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+                    >
+                      <span className="flex size-10 items-center justify-center rounded-full bg-sky-100 text-sky-500">
+                        <Icon className="size-5" aria-hidden />
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-slate-900">
+                          Step {index + 1}: {title}
+                        </p>
+                        <p className="mt-1 text-sm text-slate-600">{description}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
               </CardContent>
             </Card>
           </div>

--- a/src/components/ShiftPreviewCard.tsx
+++ b/src/components/ShiftPreviewCard.tsx
@@ -22,9 +22,14 @@ export function ShiftPreviewCard({
   location,
 }: Props) {
   return (
-    <Card className="w-full border-slate-200/70 bg-white/90 shadow-md transition hover:-translate-y-0.5 hover:shadow-lg">
-      <CardHeader className="gap-2">
-        <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
+    <Card className="relative w-full overflow-hidden border-none bg-white/90 shadow-xl shadow-slate-900/5 ring-1 ring-slate-200/70 transition hover:-translate-y-0.5 hover:shadow-2xl">
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.28),_transparent_55%),_radial-gradient(circle_at_bottom_right,_rgba(196,181,253,0.24),_transparent_50%)]"
+      />
+
+      <CardHeader className="relative z-10 gap-3">
+        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
           <MapPin className="size-4 text-sky-500" />
           {location || "Disney shift"}
         </CardTitle>
@@ -33,15 +38,19 @@ export function ShiftPreviewCard({
           <span>{date}</span>
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex items-center gap-2 text-sm font-medium text-slate-700">
-        <Clock className="size-4 text-slate-400" />
-        <span>
-          {startTime} – {endTime}
-        </span>
+
+      <CardContent className="relative z-10">
+        <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200/70">
+          <Clock className="size-4 text-sky-500" />
+          <span>
+            {startTime} – {endTime}
+          </span>
+        </div>
       </CardContent>
-      <CardFooter className="flex items-center gap-2 text-xs text-slate-500">
-        <Sparkles className="size-3 text-slate-400" />
-        Ready for export
+
+      <CardFooter className="relative z-10 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+        <Sparkles className="size-3 text-sky-500" />
+        Export ready
       </CardFooter>
     </Card>
   );

--- a/src/components/ShiftPreviewCard.tsx
+++ b/src/components/ShiftPreviewCard.tsx
@@ -1,9 +1,12 @@
 import {
   Card,
   CardContent,
-  CardHeader,
+  CardDescription,
   CardFooter,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
+import { CalendarDays, Clock, MapPin, Sparkles } from "lucide-react";
 
 type Props = {
   date: string;
@@ -19,18 +22,26 @@ export function ShiftPreviewCard({
   location,
 }: Props) {
   return (
-    <Card className="w-full">
-      <CardHeader className="text-lg font-semibold">
-        {location || "Disney Shift"}
+    <Card className="w-full border-slate-200/70 bg-white/90 shadow-md transition hover:-translate-y-0.5 hover:shadow-lg">
+      <CardHeader className="gap-2">
+        <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
+          <MapPin className="size-4 text-sky-500" />
+          {location || "Disney shift"}
+        </CardTitle>
+        <CardDescription className="flex items-center gap-2 text-sm text-slate-600">
+          <CalendarDays className="size-4 text-slate-400" />
+          <span>{date}</span>
+        </CardDescription>
       </CardHeader>
-      <CardContent>
-        <p className="text-sm">{date}</p>
-        <p className="text-sm">
+      <CardContent className="flex items-center gap-2 text-sm font-medium text-slate-700">
+        <Clock className="size-4 text-slate-400" />
+        <span>
           {startTime} – {endTime}
-        </p>
+        </span>
       </CardContent>
-      <CardFooter className="text-xs text-muted-foreground">
-        Imported from screenshot
+      <CardFooter className="flex items-center gap-2 text-xs text-slate-500">
+        <Sparkles className="size-3 text-slate-400" />
+        Ready for export
       </CardFooter>
     </Card>
   );

--- a/src/components/ShiftPreviewList.tsx
+++ b/src/components/ShiftPreviewList.tsx
@@ -11,16 +11,20 @@ export function ShiftPreviewList({ shifts }: Props) {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <ol className="relative space-y-6 border-l border-slate-200/60 pl-6">
       {shifts.map((shift, index) => (
-        <ShiftPreviewCard
-          key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`}
-          date={shift.date}
-          startTime={shift.startTime}
-          endTime={shift.endTime}
-          location={shift.location}
-        />
+        <li key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`} className="relative pl-2">
+          <span className="absolute -left-5 top-2 inline-flex size-8 items-center justify-center rounded-full bg-sky-500 text-sm font-semibold text-white shadow-md shadow-sky-500/30">
+            {index + 1}
+          </span>
+          <ShiftPreviewCard
+            date={shift.date}
+            startTime={shift.startTime}
+            endTime={shift.endTime}
+            location={shift.location}
+          />
+        </li>
       ))}
-    </div>
+    </ol>
   );
 }

--- a/src/components/ShiftPreviewList.tsx
+++ b/src/components/ShiftPreviewList.tsx
@@ -11,10 +11,10 @@ export function ShiftPreviewList({ shifts }: Props) {
   }
 
   return (
-    <div className="grid gap-4">
+    <div className="grid gap-4 md:grid-cols-2">
       {shifts.map((shift, index) => (
         <ShiftPreviewCard
-          key={index}
+          key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`}
           date={shift.date}
           startTime={shift.startTime}
           endTime={shift.endTime}

--- a/src/components/ShiftPreviewList.tsx
+++ b/src/components/ShiftPreviewList.tsx
@@ -11,18 +11,20 @@ export function ShiftPreviewList({ shifts }: Props) {
   }
 
   return (
-    <ol className="relative space-y-6 border-l border-slate-200/60 pl-6">
+    <ol className="space-y-6">
       {shifts.map((shift, index) => (
-        <li key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`} className="relative pl-2">
-          <span className="absolute -left-5 top-2 inline-flex size-8 items-center justify-center rounded-full bg-sky-500 text-sm font-semibold text-white shadow-md shadow-sky-500/30">
+        <li key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`} className="flex items-start gap-4">
+          <span className="mt-1 inline-flex size-9 items-center justify-center rounded-full bg-sky-500 text-sm font-semibold text-white shadow-lg shadow-sky-500/30">
             {index + 1}
           </span>
-          <ShiftPreviewCard
-            date={shift.date}
-            startTime={shift.startTime}
-            endTime={shift.endTime}
-            location={shift.location}
-          />
+          <div className="flex-1">
+            <ShiftPreviewCard
+              date={shift.date}
+              startTime={shift.startTime}
+              endTime={shift.endTime}
+              location={shift.location}
+            />
+          </div>
         </li>
       ))}
     </ol>


### PR DESCRIPTION
## Summary
- redesign the home page with a guided flow, polished cards, and improved call-to-actions
- add responsive shift preview styling and richer shift cards with icons
- fix .ics download request headers and show file previews with reusable helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5ab85acb48326885e6d5e179854af