### PR TITLE
Improve OCR time normalization with confidence-based overrides

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,112 +1,404 @@
 "use client";
 
+import { ShiftPreviewList } from "@/components/ShiftPreviewList";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { cleanKnownLocations } from "@/utils/cleanKnownLocations";
 import { cleanOCRText } from "@/utils/cleantext";
 import { extractTextFromImage } from "@/utils/ocr";
-import { parseScheduleFromOCR } from "@/utils/parser";
-import { useState } from "react";
-import { ScheduleEntry } from "@/utils/parser";
-import { ShiftPreviewList } from "@/components/ShiftPreviewList";
-import { cleanKnownLocations } from "@/utils/cleanKnownLocations";
+import { parseScheduleFromOCR, ScheduleEntry } from "@/utils/parser";
 import { resolveRelativeDates } from "@/utils/resolveRelativeDates";
+import { CalendarRange, Download, Loader2, Sparkles, UploadCloud, Wand2, X } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+type Step = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+const steps: Step[] = [
+  {
+    icon: UploadCloud,
+    title: "Upload your schedule",
+    description: "Add a screenshot or photo of the shifts you received from Disney.",
+  },
+  {
+    icon: Wand2,
+    title: "We read and tidy",
+    description: "Our OCR cleans messy text, detects dates, and lines up every shift.",
+  },
+  {
+    icon: CalendarRange,
+    title: "Export in one tap",
+    description: "Download a calendar-ready .ics file for Google, Apple, or Outlook.",
+  },
+];
+
+function formatFileSize(bytes: number) {
+  if (!Number.isFinite(bytes)) return "";
+  const units = ["B", "KB", "MB", "GB"];
+  const index = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** index;
+  return `${value.toFixed(value >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
 
 export default function Home() {
   const [image, setImage] = useState<File | null>(null);
-  const [ocrText, setOcrText] = useState("");
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [parsedSchedule, setParsedSchedule] = useState<ScheduleEntry[]>([]);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const uploaderRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setImage(e.target.files[0]);
-      setOcrText("");
+  useEffect(() => {
+    if (!image) {
+      setPreviewUrl(null);
+      return undefined;
     }
+
+    const objectUrl = URL.createObjectURL(image);
+    setPreviewUrl(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [image]);
+
+  const hasSchedule = parsedSchedule.length > 0;
+
+  useEffect(() => {
+    if (!isPreviewOpen) return undefined;
+
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [isPreviewOpen]);
+
+  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      setImage(event.target.files[0]);
+      setParsedSchedule([]);
+      setIsPreviewOpen(false);
+    }
+  };
+
+  const handleClearUpload = () => {
+    setImage(null);
+    setParsedSchedule([]);
+    setIsPreviewOpen(false);
+  };
+
+  const handleReplacePhoto = () => {
+    fileInputRef.current?.click();
   };
 
   const handleRunOCR = async () => {
     if (!image) return;
     setLoading(true);
+    setParsedSchedule([]);
 
-    const text = await extractTextFromImage(image);
-    const cleanedText = cleanOCRText(text);
-    const withDates = resolveRelativeDates(cleanedText);
-    const finalText = withDates.split("\n").map(cleanKnownLocations).join("\n");
+    try {
+      const { text, timeTokens } = await extractTextFromImage(image);
+      const cleanedText = cleanOCRText(text);
+      const withDates = resolveRelativeDates(cleanedText);
+      const finalText = withDates.split("\n").map(cleanKnownLocations).join("\n");
 
-    setOcrText(finalText);
-
-    const parsed = parseScheduleFromOCR(finalText);
-    setParsedSchedule(parsed);
-    setLoading(false);
+      const parsed = parseScheduleFromOCR(finalText, timeTokens);
+      setParsedSchedule(parsed);
+    } catch (error) {
+      console.error("Failed to extract schedule", error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleDownloadICS = async () => {
     const res = await fetch("/api/generate-ics", {
       method: "POST",
-      headers: { "Content-Type": "applicaiton/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(parsedSchedule),
     });
 
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "disney_schedule.ics";
-    a.click();
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "disney_schedule.ics";
+    link.click();
     URL.revokeObjectURL(url);
   };
 
+  const handleOpenPreview = () => {
+    if (!previewUrl) return;
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
+
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen px-4 py-8 bg-slate-400">
-      <h1 className="text-3xl font-bold mb-6 text-center">
-        Disney Schedule to Calendar
-      </h1>
+    <main className="relative min-h-screen overflow-hidden bg-slate-950">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.22),_transparent_60%),_radial-gradient(circle_at_bottom,_rgba(167,139,250,0.18),_transparent_55%)]" />
 
-      <label
-        htmlFor="file-upload"
-        className="flex items-center justify-center w-full max-w-sm px-4 py-2 bg-blue-600 text-white rounded-lg shadow-md cursor-pointer hover:bg-blue-700 transition mb-4"
-      >
-        <input
-          id="file-upload"
-          type="file"
-          className="hidden"
-          onChange={handleFileUpload}
-          accept="image/*"
-        />
-        Upload Schedule Image
-      </label>
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-16 sm:px-8">
+        <header className="mx-auto max-w-3xl text-center text-slate-100">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-sm font-medium uppercase tracking-wide text-sky-100 backdrop-blur">
+            <Sparkles className="size-4" />
+            Disney cast member helper
+          </span>
+          <h1 className="mt-6 text-4xl font-semibold sm:text-5xl">
+            Turn your Disney shifts into a polished calendar in seconds
+          </h1>
+          <p className="mt-4 text-lg text-slate-200">
+            Upload your schedule screenshot, let our OCR do the busy work, and download a clean .ics file ready to drop into your favorite calendar.
+          </p>
+          <div className="mt-8 grid w-full gap-4 rounded-3xl border border-white/20 bg-white/10 p-6 text-left text-slate-100 backdrop-blur sm:grid-cols-3">
+            {steps.map(({ icon: Icon, title, description }, index) => (
+              <div
+                key={title}
+                className="group relative flex flex-col gap-3 overflow-hidden rounded-2xl border border-white/20 bg-white/5 p-4 shadow-lg shadow-slate-950/20 transition duration-300 hover:-translate-y-1 hover:border-sky-300/60 hover:shadow-sky-500/30"
+              >
+                <span className="pointer-events-none absolute inset-0 opacity-0 transition duration-300 group-hover:opacity-100">
+                  <span className="absolute inset-0 bg-gradient-to-br from-sky-400/15 via-transparent to-violet-400/20" />
+                </span>
+                <span className="inline-flex size-12 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-sky-100 transition-transform duration-300 group-hover:scale-105 group-hover:border-sky-200/80 group-hover:bg-white/20">
+                  <Icon className="size-5" aria-hidden />
+                </span>
+                <div className="relative">
+                  <p className="text-sm font-semibold uppercase tracking-wide text-sky-100/90">
+                    Step {index + 1}: {title}
+                  </p>
+                  <p className="mt-2 text-sm text-slate-200/80">{description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </header>
 
-      {image && (
-        <>
-          <img
-            src={URL.createObjectURL(image)}
-            alt="Uploaded Preview"
-            className="max-h-64 border rounded mb-4"
-          />
-          <button
-            onClick={handleRunOCR}
-            disabled={loading}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition mb-4"
-          >
-            {loading ? "Processing..." : "Extract Text"}
-          </button>
-        </>
-      )}
-      {ocrText && process.env.NEXT_PUBLIC_VERCEL_ENV === "preview" && (
-        <div className="mt-6 w-full max-w-2xl bg-gray-100 p-4 rounded text-sm whitespace-pre-wrap">
-          <h2 className="font-semibold text-lg mb-2">OCR Result:</h2>
-          <p className="text-black">{ocrText}</p>
-        </div>
-      )}
-      {parsedSchedule.length > 0 && (
-        <ShiftPreviewList shifts={parsedSchedule} />
-      )}
-
-      {parsedSchedule?.length > 0 && (
-        <button
-          onClick={handleDownloadICS}
-          className="mt-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green700"
+        <div
+          ref={uploaderRef}
+          className="mt-16 grid flex-1 gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]"
         >
-          Download .ics File
-        </button>
+          <Card className="border-white/20 bg-white/85 shadow-2xl shadow-sky-500/10 backdrop-blur">
+            <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <CardTitle className="flex items-center gap-2 text-2xl text-slate-900">
+                  <Wand2 className="size-6 text-sky-500" />
+                  Upload & preview your schedule
+                </CardTitle>
+                <CardDescription className="max-w-xl text-slate-600">
+                  Start by selecting a screenshot of your shifts. Tap the preview to pop it into a distraction-free full-screen view before running the extractor.
+                </CardDescription>
+              </div>
+              {image && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="self-start text-slate-500 hover:text-slate-900"
+                  onClick={handleClearUpload}
+                >
+                  <X className="size-4" />
+                  Remove image
+                </Button>
+              )}
+            </CardHeader>
+            <CardContent className="space-y-8">
+              <input
+                id="file-upload"
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                onChange={handleFileUpload}
+              />
+
+              {image && previewUrl ? (
+                <div className="space-y-5">
+                  <div
+                    role="presentation"
+                    className="group relative max-h-[28rem] overflow-hidden rounded-3xl border border-slate-200/80 bg-slate-950/60 shadow-inner"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={previewUrl}
+                      alt="Uploaded schedule preview"
+                      className="mx-auto block max-h-[32rem] w-full origin-center bg-slate-900/40 object-contain transition duration-300 ease-out group-hover:scale-[1.02]"
+                      onClick={handleOpenPreview}
+                    />
+
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 flex flex-wrap items-center justify-between gap-3 bg-gradient-to-t from-slate-950/90 via-slate-950/50 to-transparent p-4 text-slate-100">
+                      <div>
+                        <p className="text-sm font-semibold leading-tight">{image.name}</p>
+                        <p className="text-xs text-slate-300/80">{formatFileSize(image.size)}</p>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="pointer-events-auto bg-white/90 text-slate-900 hover:bg-white"
+                        onClick={handleReplacePhoto}
+                      >
+                        <UploadCloud className="size-3.5" />
+                        Replace photo
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <label
+                  htmlFor="file-upload"
+                  className={cn(
+                    "group relative flex cursor-pointer flex-col items-center justify-center gap-3 rounded-3xl border-2 border-dashed border-slate-300 bg-white/75 px-8 py-16 text-center transition hover:border-sky-400 hover:bg-white",
+                    loading && "pointer-events-none opacity-70"
+                  )}
+                >
+                  <div className="flex size-20 items-center justify-center rounded-full bg-sky-100 text-sky-500 shadow-inner transition group-hover:scale-105">
+                    <UploadCloud className="size-8" />
+                  </div>
+                  <p className="text-xl font-semibold text-slate-900">Drag & drop or browse for your schedule</p>
+                  <p className="max-w-md text-sm text-slate-500">
+                    JPG, PNG, and HEIC images are supported. Crystal clear photos give the extractor the best chance to nail every
+                    shift.
+                  </p>
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-400">Click to choose a file</span>
+                </label>
+              )}
+
+            </CardContent>
+            <CardFooter className="flex flex-col gap-4 border-t border-slate-200/70 pt-6 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-slate-500">Run the extractor to populate your shifts, then export them to your calendar.</p>
+              <Button
+                type="button"
+                onClick={handleRunOCR}
+                disabled={!image || loading}
+                className="w-full gap-2 bg-sky-500 text-white hover:bg-sky-500/90 sm:w-auto"
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Scanning upload…
+                  </>
+                ) : (
+                  <>
+                    <Wand2 className="size-4" />
+                    Extract shifts
+                  </>
+                )}
+              </Button>
+            </CardFooter>
+          </Card>
+
+          <div className="flex flex-col gap-6">
+            <Card className="border-white/30 bg-white/80 shadow-xl shadow-sky-500/5 backdrop-blur">
+              <CardHeader className="flex flex-wrap items-center gap-2">
+                <CardTitle className="flex items-center gap-2 text-xl text-slate-900">
+                  <CalendarRange className="size-5 text-sky-500" />
+                  Shift preview
+                </CardTitle>
+                {hasSchedule && (
+                  <span className="rounded-full bg-sky-100 px-3 py-1 text-sm font-medium text-sky-600">
+                    {parsedSchedule.length} shift{parsedSchedule.length > 1 ? "s" : ""} detected
+                  </span>
+                )}
+                <CardDescription className="basis-full text-slate-600">
+                  Review the extracted shifts below. We’ll keep them ordered exactly as they appear on your schedule.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                {loading && (
+                  <div className="flex items-center gap-3 rounded-2xl border border-sky-200 bg-sky-50/80 p-4 text-sky-700">
+                    <Loader2 className="size-4 animate-spin" />
+                    <div>
+                      <p className="text-sm font-medium">Scanning your upload</p>
+                      <p className="text-xs text-sky-600/80">Hang tight—this usually wraps up in just a few seconds.</p>
+                    </div>
+                  </div>
+                )}
+
+                {hasSchedule ? (
+                  <ShiftPreviewList shifts={parsedSchedule} />
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-slate-300 bg-white/60 p-6 text-center text-slate-500">
+                    <p className="text-sm font-medium">No shifts yet—run the extractor to see them here.</p>
+                    <p className="mt-2 text-xs text-slate-400">
+                      Tip: ensure dates and times are sharp and unobstructed for the most accurate results.
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+
+              {hasSchedule && (
+                <CardFooter className="flex flex-col gap-4 border-t border-slate-200/70 pt-6 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm text-slate-600">
+                    Looks good? Download your shifts as an .ics calendar file.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleDownloadICS}
+                    disabled={!hasSchedule}
+                    className="w-full gap-2 border-slate-300 text-slate-700 hover:border-sky-400 hover:text-sky-600 sm:w-auto"
+                  >
+                    <Download className="size-4" />
+                    Download .ics file
+                  </Button>
+                </CardFooter>
+              )}
+            </Card>
+
+          </div>
+        </div>
+      </div>
+
+      {isPreviewOpen && previewUrl && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-slate-950/90 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+        >
+          <button
+            type="button"
+            className="absolute inset-0 z-0 h-full w-full cursor-zoom-out"
+            onClick={handleClosePreview}
+            aria-label="Close preview"
+          />
+          <div className="relative z-10 mx-auto w-full max-w-5xl p-6">
+            <div className="relative mx-auto max-h-[calc(100vh-3rem)] overflow-auto rounded-3xl border border-white/20 bg-slate-950/70 p-4 shadow-2xl">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="Full size schedule preview"
+                className="mx-auto block h-auto max-h-[calc(100vh-7rem)] w-full max-w-full object-contain"
+              />
+            </div>
+            <Button
+              type="button"
+              size="icon"
+              variant="secondary"
+              className="absolute right-10 top-10 rounded-full bg-white/90 text-slate-900 hover:bg-white"
+              onClick={handleClosePreview}
+            >
+              <X className="size-5" />
+              <span className="sr-only">Close preview</span>
+            </Button>
+          </div>
+        </div>
       )}
     </main>
   );

--- a/src/components/ShiftPreviewCard.tsx
+++ b/src/components/ShiftPreviewCard.tsx
@@ -1,9 +1,12 @@
 import {
   Card,
   CardContent,
-  CardHeader,
+  CardDescription,
   CardFooter,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
+import { CalendarDays, Clock, MapPin, Sparkles } from "lucide-react";
 
 type Props = {
   date: string;
@@ -19,18 +22,35 @@ export function ShiftPreviewCard({
   location,
 }: Props) {
   return (
-    <Card className="w-full">
-      <CardHeader className="text-lg font-semibold">
-        {location || "Disney Shift"}
+    <Card className="relative w-full overflow-hidden border-none bg-white/90 shadow-xl shadow-slate-900/5 ring-1 ring-slate-200/70 transition hover:-translate-y-0.5 hover:shadow-2xl">
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.28),_transparent_55%),_radial-gradient(circle_at_bottom_right,_rgba(196,181,253,0.24),_transparent_50%)]"
+      />
+
+      <CardHeader className="relative z-10 gap-3">
+        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+          <MapPin className="size-4 text-sky-500" />
+          {location || "Disney shift"}
+        </CardTitle>
+        <CardDescription className="flex items-center gap-2 text-sm text-slate-600">
+          <CalendarDays className="size-4 text-slate-400" />
+          <span>{date}</span>
+        </CardDescription>
       </CardHeader>
-      <CardContent>
-        <p className="text-sm">{date}</p>
-        <p className="text-sm">
-          {startTime} – {endTime}
-        </p>
+
+      <CardContent className="relative z-10">
+        <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm ring-1 ring-slate-200/70">
+          <Clock className="size-4 text-sky-500" />
+          <span>
+            {startTime} – {endTime}
+          </span>
+        </div>
       </CardContent>
-      <CardFooter className="text-xs text-muted-foreground">
-        Imported from screenshot
+
+      <CardFooter className="relative z-10 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+        <Sparkles className="size-3 text-sky-500" />
+        Export ready
       </CardFooter>
     </Card>
   );

--- a/src/components/ShiftPreviewList.tsx
+++ b/src/components/ShiftPreviewList.tsx
@@ -11,16 +11,22 @@ export function ShiftPreviewList({ shifts }: Props) {
   }
 
   return (
-    <div className="grid gap-4">
+    <ol className="space-y-6">
       {shifts.map((shift, index) => (
-        <ShiftPreviewCard
-          key={index}
-          date={shift.date}
-          startTime={shift.startTime}
-          endTime={shift.endTime}
-          location={shift.location}
-        />
+        <li key={`${shift.date}-${shift.startTime}-${shift.endTime}-${index}`} className="flex items-start gap-4">
+          <span className="mt-1 inline-flex size-9 items-center justify-center rounded-full bg-sky-500 text-sm font-semibold text-white shadow-lg shadow-sky-500/30">
+            {index + 1}
+          </span>
+          <div className="flex-1">
+            <ShiftPreviewCard
+              date={shift.date}
+              startTime={shift.startTime}
+              endTime={shift.endTime}
+              location={shift.location}
+            />
+          </div>
+        </li>
       ))}
-    </div>
+    </ol>
   );
 }

--- a/src/utils/cleanKnownLocations.ts
+++ b/src/utils/cleanKnownLocations.ts
@@ -1,4 +1,13 @@
-const knownLocations = ["Falcon HH", "Rise", "Adventureland", "Tomorrowland"];
+const knownLocations = [
+  "Falcon HH",
+  "Rise",
+  "Adventureland",
+  "Tomorrowland",
+  "CDs Trn T",
+  "Resistance HH",
+  "Falcon",
+  "Mermaid Lagoon",
+];
 
 export function cleanKnownLocations(line: string): string {
   for (const location of knownLocations) {

--- a/src/utils/ocr.ts
+++ b/src/utils/ocr.ts
@@ -96,9 +96,9 @@ export async function extractTextFromImage(
       tessedit_pageseg_mode: PSM.SINGLE_COLUMN,
     });
 
-    const {
-      data: { text, words },
-    } = await worker.recognize(source);
+    const result = await worker.recognize(source);
+    const { text } = result.data;
+    const words = (result.data as typeof result.data & { words?: Word[] }).words;
 
     await worker.terminate();
     const timeTokens = collectTimeOverrides(words ?? undefined);

--- a/src/utils/ocr.ts
+++ b/src/utils/ocr.ts
@@ -1,17 +1,111 @@
-import { createWorker } from "tesseract.js";
+import { PSM, createWorker } from "tesseract.js";
+import type { Word } from "tesseract.js";
+import { preprocessImageForOCR } from "./preprocessImage";
+import { normaliseTimeCandidate, TimeTokenOverride } from "./timeTokens";
 
-export async function extractTextFromImage(image: File): Promise<string> {
+function scoreTimeCandidates(word: Word): TimeTokenOverride | null {
+  const baseCandidate = normaliseTimeCandidate(word.text);
+  const allChoices = [
+    { text: word.text, confidence: word.confidence },
+    ...(word.choices ?? []),
+  ];
+
+  const seen = new Set<string>();
+  const candidates = allChoices
+    .map(({ text, confidence }) => {
+      if (!text || seen.has(text)) return null;
+      seen.add(text);
+
+      const normalized = normaliseTimeCandidate(text);
+      if (!normalized) return null;
+
+      return { normalized, confidence };
+    })
+    .filter((value): value is { normalized: string; confidence: number } => value !== null);
+
+  if (!candidates.length && !baseCandidate) {
+    return null;
+  }
+
+  const quarterTargets = [0, 15, 30, 45];
+
+  const scored = candidates.map((candidate) => {
+    const minutes = Number(candidate.normalized.split(":")[1]);
+    const quarterDistance = Math.min(
+      ...quarterTargets.map((target) => Math.abs(target - minutes)),
+    );
+
+    const score = candidate.confidence - quarterDistance * 8;
+
+    return { ...candidate, quarterDistance, score };
+  });
+
+  let best = scored[0] ?? null;
+  for (let i = 1; i < scored.length; i++) {
+    const candidate = scored[i];
+    if (!best || candidate.score > best.score) {
+      best = candidate;
+      continue;
+    }
+
+    if (candidate.score === best.score && candidate.quarterDistance < best.quarterDistance) {
+      best = candidate;
+    }
+  }
+
+  const corrected = best?.normalized ?? baseCandidate;
+  if (!corrected) {
+    return null;
+  }
+
+  const raw = baseCandidate ?? corrected;
+  return { raw, corrected };
+}
+
+function collectTimeOverrides(words: Word[] | undefined): TimeTokenOverride[] {
+  if (!words) return [];
+
+  const overrides: TimeTokenOverride[] = [];
+
+  for (const word of words) {
+    if (!/[:.]/.test(word.text)) {
+      continue;
+    }
+
+    const override = scoreTimeCandidates(word);
+    if (override) {
+      overrides.push(override);
+    }
+  }
+
+  return overrides;
+}
+
+export async function extractTextFromImage(
+  image: File,
+): Promise<{ text: string; timeTokens: TimeTokenOverride[] }> {
   const worker = await createWorker("eng");
 
   try {
+    const source = await preprocessImageForOCR(image);
+
+    await worker.setParameters({
+      tessedit_char_whitelist:
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789:-/,. ",
+      preserve_interword_spaces: "1",
+      tessedit_pageseg_mode: PSM.SINGLE_COLUMN,
+    });
+
     const {
-      data: { text },
-    } = await worker.recognize(image);
+      data: { text, words },
+    } = await worker.recognize(source);
 
     await worker.terminate();
-    return text;
+    const timeTokens = collectTimeOverrides(words ?? undefined);
+    return { text, timeTokens };
   } catch (err) {
     console.error("OCR failed:", err);
-    return "Error extracting text";
+    await worker.terminate();
+    return { text: "Error extracting text", timeTokens: [] };
   }
 }

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,4 +1,5 @@
 import { convertTo24Hour } from "./convertTo24Hour";
+import { normaliseTimeToken, timeTokenRegex, TimeTokenOverride } from "./timeTokens";
 
 export interface ScheduleEntry {
   date: string;
@@ -7,41 +8,120 @@ export interface ScheduleEntry {
   location: string;
 }
 
-export function parseScheduleFromOCR(text: string): ScheduleEntry[] {
-  const lines = text.split("\n").map((l) => l.trim());
+const monthPattern =
+  "(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*";
+const dayPattern =
+  "(?:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)";
+
+const dateRegex = new RegExp(
+  `^${monthPattern}\\s+\\d{1,2},\\s*\\d{4}(?:\\s+${dayPattern})?$`,
+  "i",
+);
+const dayRegex = new RegExp(`^${dayPattern}$`, "i");
+const timeRangeRegex =
+  /(\d{1,2}[:.]\d{2})\s*(AM|PM)?\s*(?:to|[-–])\s*(\d{1,2}[:.]\d{2})\s*(AM|PM)?/i;
+
+function normaliseLine(line: string): string {
+  const cleaned = line
+    .replace(/[•|]/g, " ")
+    .replace(/[–—]/g, "-")
+    .replace(/O'Clock/gi, ":00")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return cleaned.replace(timeTokenRegex, (_, hours: string, _separator: string, minutes: string) => {
+    const normalisedHours = normaliseTimeToken(hours);
+    const normalisedMinutes = normaliseTimeToken(minutes);
+    return `${normalisedHours}:${normalisedMinutes}`;
+  });
+}
+
+function createTimeOverrideFinder(overrides: TimeTokenOverride[]) {
+  let cursor = 0;
+
+  return (raw: string): string => {
+    if (!overrides.length) return raw;
+
+    for (let i = cursor; i < overrides.length; i++) {
+      const candidate = overrides[i];
+      if (candidate.raw === raw) {
+        cursor = i + 1;
+        return candidate.corrected;
+      }
+    }
+
+    return raw;
+  };
+}
+
+export function parseScheduleFromOCR(
+  text: string,
+  timeOverrides: TimeTokenOverride[] = [],
+): ScheduleEntry[] {
+  const lines = text.split("\n").map((l) => normaliseLine(l));
   const entries: ScheduleEntry[] = [];
 
   let currentDate = "";
-  let currentLocation = "";
-  let timeMatch: RegExpMatchArray | null = null;
+  const resolveOverride = createTimeOverrideFinder(timeOverrides);
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+    if (!line) continue;
 
-    const dateMatch = line.match(/^[A-Z][a-z]{2}\s?0?\d{1,2},\s?\d{4}\s*$/);
-    if (dateMatch) {
-      currentDate = dateMatch[0];
+    if (dateRegex.test(line)) {
+      currentDate = line.replace(new RegExp(`\\s+${dayPattern}$`, "i"), "");
       continue;
     }
 
-    const timeRangeRegex =
-      /(\d{1,2}:\d{2})\s*(AM|PM)?\s*to\s*(\d{1,2}:\d{2})\s*(AM|PM)?/i;
-    // old regex: /(\d{1,2}:\d{2})\s*(?:to|-|-)?\s*(\d{1,2}:\d{2})/
-    timeMatch = line.match(timeRangeRegex);
+    if (dayRegex.test(line)) {
+      continue;
+    }
+
+    const timeMatch = line.match(timeRangeRegex);
     if (timeMatch && currentDate) {
       const [, rawStart, startAMPM, rawEnd, endAMPM] = timeMatch;
-      const startTime = convertTo24Hour(rawStart, startAMPM);
-      const endTime = convertTo24Hour(rawEnd, endAMPM);
-      const nextLine = lines[i + 1] || "";
-      const locationMatch = nextLine.match(/[A-Za-z\s]{4,}/);
-      currentLocation = locationMatch?.[0]?.trim() || "Unknown";
+      const startToken = resolveOverride(rawStart.replace(".", ":"));
+      const endToken = resolveOverride(rawEnd.replace(".", ":"));
 
-      if (currentDate) {
-        entries.push({
-          date: currentDate,
-          startTime: startTime,
-          endTime: endTime,
-          location: currentLocation,
-        });
+      const startTime = convertTo24Hour(startToken, startAMPM);
+      const endTime = convertTo24Hour(endToken, endAMPM);
+
+      const locationParts: string[] = [];
+      let pointer = i + 1;
+      while (pointer < lines.length) {
+        const next = lines[pointer];
+        if (!next) {
+          pointer++;
+          continue;
+        }
+        if (dateRegex.test(next) || timeRangeRegex.test(next) || dayRegex.test(next)) {
+          break;
+        }
+        locationParts.push(next);
+        pointer++;
+      }
+
+      const filteredLocation = locationParts
+        .map((part) => part.replace(/Pick up (?:a )?shift[s]?/gi, "").trim())
+        .filter(
+          (part) =>
+            part &&
+            !/pick\s+up/i.test(part) &&
+            !/shift exchange/i.test(part) &&
+            !/schedule tools/i.test(part) &&
+            !/jump to week/i.test(part),
+        );
+
+      const location = filteredLocation[0]?.trim() || "Unknown";
+      entries.push({
+        date: currentDate,
+        startTime,
+        endTime,
+        location,
+      });
+
+      if (pointer > i + 1) {
+        i = pointer - 1;
       }
     }
   }

--- a/src/utils/preprocessImage.ts
+++ b/src/utils/preprocessImage.ts
@@ -1,0 +1,118 @@
+type DrawableSource = {
+  width: number;
+  height: number;
+  draw: (context: CanvasRenderingContext2D, width: number, height: number) => void;
+  cleanup?: () => void;
+};
+
+async function createDrawableFromFile(image: File): Promise<DrawableSource | null> {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if ("createImageBitmap" in window) {
+    try {
+      const bitmap = await createImageBitmap(image);
+      return {
+        width: bitmap.width,
+        height: bitmap.height,
+        draw: (context, width, height) => context.drawImage(bitmap, 0, 0, width, height),
+        cleanup: () => bitmap.close(),
+      };
+    } catch (error) {
+      console.warn("createImageBitmap failed, trying image element fallback", error);
+    }
+  }
+
+  return new Promise<DrawableSource | null>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({
+        width: img.naturalWidth || img.width,
+        height: img.naturalHeight || img.height,
+        draw: (context, width, height) => context.drawImage(img, 0, 0, width, height),
+      });
+    };
+    img.onerror = (err) => reject(err);
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        img.src = reader.result;
+      } else {
+        reject(new Error("Unable to read image data"));
+      }
+    };
+    reader.onerror = (err) => reject(err);
+    reader.readAsDataURL(image);
+  }).catch((error) => {
+    console.error("Failed to create drawable source", error);
+    return null;
+  });
+}
+
+export async function preprocessImageForOCR(image: File): Promise<File | Blob> {
+  if (typeof window === "undefined") {
+    return image;
+  }
+
+  try {
+    const drawable = await createDrawableFromFile(image);
+    if (!drawable) {
+      return image;
+    }
+
+    const MAX_DIMENSION = 2200;
+    const largestSide = Math.max(drawable.width, drawable.height);
+    const scale = largestSide > MAX_DIMENSION ? MAX_DIMENSION / largestSide : 1;
+    const targetWidth = Math.round(drawable.width * scale);
+    const targetHeight = Math.round(drawable.height * scale);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      drawable.cleanup?.();
+      return image;
+    }
+
+    drawable.draw(context, targetWidth, targetHeight);
+    drawable.cleanup?.();
+
+    const imageData = context.getImageData(0, 0, targetWidth, targetHeight);
+    const { data } = imageData;
+
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+
+      const grayscale = 0.299 * r + 0.587 * g + 0.114 * b;
+      const contrasted = Math.min(255, Math.max(0, (grayscale - 128) * 1.2 + 128));
+      const threshold = contrasted > 200 ? 255 : contrasted < 60 ? 0 : contrasted;
+
+      data[i] = threshold;
+      data[i + 1] = threshold;
+      data[i + 2] = threshold;
+    }
+
+    context.putImageData(imageData, 0, 0);
+
+    const processed = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((blob) => resolve(blob), "image/png", 1);
+    });
+
+    if (!processed) {
+      return image;
+    }
+
+    return new File([processed], `${image.name.replace(/\.[^.]+$/, "")}-enhanced.png`, {
+      type: "image/png",
+    });
+  } catch (error) {
+    console.error("Failed to preprocess image", error);
+    return image;
+  }
+}

--- a/src/utils/timeTokens.ts
+++ b/src/utils/timeTokens.ts
@@ -1,0 +1,50 @@
+const timeLookalikeMap: Record<string, string> = {
+  O: "0",
+  o: "0",
+  "|": "1",
+  l: "1",
+  I: "1",
+  B: "8",
+  S: "5",
+  s: "5",
+};
+
+export const timeTokenRegex = /([0-9OolISB]{1,2})([:.])([0-9OolISB]{2})/g;
+
+export interface TimeTokenOverride {
+  raw: string;
+  corrected: string;
+}
+
+export function normaliseTimeToken(segment: string): string {
+  return segment
+    .split("")
+    .map((char) => timeLookalikeMap[char] ?? char)
+    .join("");
+}
+
+export function normaliseTimeCandidate(candidate: string): string | null {
+  if (!candidate) return null;
+
+  const trimmed = candidate.replace(/[^0-9A-Za-z:.]/g, "");
+  if (!trimmed) return null;
+
+  const withColon = trimmed.replace(/[.]/g, ":");
+  const match = withColon.match(/^([0-9OolISB]{1,2}):([0-9OolISB]{1,3})$/);
+  if (!match) return null;
+
+  const [, rawHours, rawMinutes] = match;
+  const hours = normaliseTimeToken(rawHours);
+  const minutesChars = normaliseTimeToken(rawMinutes);
+
+  if (!hours || !minutesChars) return null;
+
+  const minutes =
+    minutesChars.length === 1 ? minutesChars.padStart(2, "0") : minutesChars.slice(0, 2);
+
+  if (!/^\d{1,2}$/.test(hours) || !/^\d{2}$/.test(minutes)) {
+    return null;
+  }
+
+  return `${hours}:${minutes}`;
+}


### PR DESCRIPTION
## Summary
- share time token normalization helpers so OCR and parsing use the same cleanup logic
- collect high-confidence quarter-hour overrides from Tesseract word choices and return them with OCR results
- apply the overrides when parsing schedules so UI renders corrected start and end times

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5ab85acb48326885e6d5e179854af